### PR TITLE
Fix bug in which world rotation applied to relative X, Z pos of groun…

### DIFF
--- a/Assets/Scenes/TestScenes/InputSystem.unity
+++ b/Assets/Scenes/TestScenes/InputSystem.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.44657898, g: 0.4964133, b: 0.5748178, a: 1}
+  m_IndirectSpecularColor: {r: 0.44657874, g: 0.49641258, b: 0.5748172, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -141,6 +141,14 @@ PrefabInstance:
     - target: {fileID: 261343388298970710, guid: c6a673c31577ffc4086491bd7594fed5, type: 3}
       propertyPath: m_ActionEvents.Array.data[5].m_ActionName
       value: Gameplay/Jump[/Keyboard/space,/XInputControllerWindows/buttonSouth]
+      objectReference: {fileID: 0}
+    - target: {fileID: 1518754503120927866, guid: c6a673c31577ffc4086491bd7594fed5, type: 3}
+      propertyPath: depth
+      value: 0.98
+      objectReference: {fileID: 0}
+    - target: {fileID: 1518754503120927866, guid: c6a673c31577ffc4086491bd7594fed5, type: 3}
+      propertyPath: width
+      value: 0.98
       objectReference: {fileID: 0}
     - target: {fileID: 4265735082826765354, guid: c6a673c31577ffc4086491bd7594fed5, type: 3}
       propertyPath: m_Name

--- a/Assets/Scripts/Physics/PhysicsObjects/DynamicObject.cs
+++ b/Assets/Scripts/Physics/PhysicsObjects/DynamicObject.cs
@@ -39,7 +39,7 @@ public class DynamicObject : MonoBehaviour
     // Update is called once per frame
     void FixedUpdate()
     {
-        if(analyser.IsLayerClose(groundLayer, worldRotation.Value))
+        if(analyser.IsLayerDown(groundLayer, transform.position, worldRotation.Value))
         {
             data.SetGrounded(true);
             data.SetSafePosition(transform.position);

--- a/Assets/Scripts/Physics/Queries/RelativeLayerMaskQuery.cs
+++ b/Assets/Scripts/Physics/Queries/RelativeLayerMaskQuery.cs
@@ -19,9 +19,13 @@ public class RelativeLayerMaskQuery : MonoBehaviour
     /**
 	 * Returns whether or not layer is to the below, relative to rotation.
 	 */
-    public bool IsLayerClose(LayerMask layer, Quaternion rotation)
+    public bool IsLayerDown(LayerMask layer, Vector3 position, Quaternion rotation)
     {
-        Vector3 floor_pos = rotation * (transform.position + Vector3.down * (height * 0.5f + delta * 0.5f));
-        return Physics.OverlapBoxNonAlloc(floor_pos, new Vector3(width *0.5f, delta * 0.5f, depth * 0.5f), preallocatedCollider, rotation, layer) != 0;
+        return Physics.OverlapBoxNonAlloc(GetFloorPosition(position, rotation), new Vector3(width * 0.5f, delta * 0.5f, depth * 0.5f), preallocatedCollider, rotation, layer) != 0;
+    }
+
+    private Vector3 GetFloorPosition(Vector3 position, Quaternion rotation)
+    {
+        return position + (rotation * Vector3.down * (height * 0.5f + delta * 0.5f));
     }
 }


### PR DESCRIPTION
…d check

Today's ugliest commit message goes to^

Anyway, fixed the floor_pos calculation, refactored a tad, changed the method name, and changed width and depth of the player ground check to disallow wall climbing