### PR TITLE
Fixed safe pos bug. Fixes #27

### DIFF
--- a/Assets/Prefabs/Player/TestPlayer.prefab
+++ b/Assets/Prefabs/Player/TestPlayer.prefab
@@ -34,7 +34,7 @@ Transform:
   m_GameObject: {fileID: 4265735082826765354}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0.064735174, y: 6.23, z: -3.359319}
-  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalScale: {x: 0.75, y: 0.75, z: 0.75}
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 0
@@ -167,9 +167,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 906c90b31e6d0564f9e0d0342cee4992, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  width: 1
+  width: 0.75
   height: 1
-  depth: 1
+  depth: 0.75
   delta: 0.05
 --- !u!114 &9180218301881872892
 MonoBehaviour:

--- a/Assets/Prefabs/Player/TestPlayer.prefab
+++ b/Assets/Prefabs/Player/TestPlayer.prefab
@@ -167,9 +167,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 906c90b31e6d0564f9e0d0342cee4992, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  width: 0.98
+  width: 1
   height: 1
-  depth: 0.98
+  depth: 1
   delta: 0.05
 --- !u!114 &9180218301881872892
 MonoBehaviour:

--- a/Assets/Scripts/Physics/PhysicsObjects/DynamicObject.cs
+++ b/Assets/Scripts/Physics/PhysicsObjects/DynamicObject.cs
@@ -73,7 +73,8 @@ public class DynamicObject : MonoBehaviour
 
     private void SetData()
     {
-        if (analyser.IsLayerDown(groundLayer, transform.position, worldRotation.Value))
+        if (analyser.IsLayerDown(groundLayer, transform.position, worldRotation.Value) 
+            && Mathf.Abs(Vector3.Dot(worldRotation.Value * Vector3.down, body.velocity)) < 1e-6f)
         {
             data.SetGrounded(true);
             data.SetSafePosition(transform.position);

--- a/Assets/Scripts/Physics/Queries/RelativeLayerMaskQuery.cs
+++ b/Assets/Scripts/Physics/Queries/RelativeLayerMaskQuery.cs
@@ -16,6 +16,13 @@ public class RelativeLayerMaskQuery : MonoBehaviour
 
     private Collider[] preallocatedCollider = new Collider[1];
 
+    void Start()
+    {
+        width *= transform.localScale.x;
+        height *= transform.localScale.y;
+        depth *= transform.localScale.z;
+    }
+
     /**
 	 * Returns whether or not layer is to the below, relative to rotation.
 	 */


### PR DESCRIPTION
Safe pos and is grounded are only set now if the vertical velocity of the object is very small. I also increased the width and depth of the physics query back to 1 since it no longer is a problem.