### PR TITLE
Add custom Vector2 Input Deadzone component, Fixes #50

### DIFF
--- a/Assets/Prefabs/World/WorldRotation.prefab
+++ b/Assets/Prefabs/World/WorldRotation.prefab
@@ -15,6 +15,7 @@ GameObject:
   - component: {fileID: 263376748743205273}
   - component: {fileID: 3904455850313593963}
   - component: {fileID: 7172797582904183920}
+  - component: {fileID: 309254960}
   m_Layer: 0
   m_Name: WorldRotation
   m_TagString: Untagged
@@ -143,9 +144,9 @@ MonoBehaviour:
     m_ActionName: Gameplay/ResetLevel[/Keyboard/r,/XInputControllerWindows/leftShoulder,/XInputControllerWindows/rightShoulder]
   - m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 4194240920654859459}
-        m_TargetAssemblyTypeName: WorldRotationInputListener, Assembly-CSharp
-        m_MethodName: OnRotate
+      - m_Target: {fileID: 309254960}
+        m_TargetAssemblyTypeName: Vector2InputDeadzone, Assembly-CSharp
+        m_MethodName: OnInput
         m_Mode: 0
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -189,7 +190,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   isTimeStopped:
-    useConstant: 0
+    useConstant: 1
     constantValue: 1
     variable: {fileID: 11400000, guid: 0f86695ec020656469e20498a1230c38, type: 2}
   rotationInputMapping: {fileID: 11400000, guid: ebef3ea3f63eaa547827061891eedadf, type: 2}
@@ -266,3 +267,34 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
+--- !u!114 &309254960
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4194240920654859457}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 34c509e5488763542b074348c53ebcb2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  deadzone: 0.75
+  OnInputStarted:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 4194240920654859459}
+        m_TargetAssemblyTypeName: WorldRotationInputListener, Assembly-CSharp
+        m_MethodName: OnRotate
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+  OnInputCanceled:
+    m_PersistentCalls:
+      m_Calls: []

--- a/Assets/Prefabs/World/WorldRotation.prefab
+++ b/Assets/Prefabs/World/WorldRotation.prefab
@@ -190,7 +190,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   isTimeStopped:
-    useConstant: 1
+    useConstant: 0
     constantValue: 1
     variable: {fileID: 11400000, guid: 0f86695ec020656469e20498a1230c38, type: 2}
   rotationInputMapping: {fileID: 11400000, guid: ebef3ea3f63eaa547827061891eedadf, type: 2}

--- a/Assets/Scenes/TestScenes/InputSystem.unity
+++ b/Assets/Scenes/TestScenes/InputSystem.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.44657874, g: 0.49641258, b: 0.5748172, a: 1}
+  m_IndirectSpecularColor: {r: 0.43667555, g: 0.48427182, b: 0.5645241, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:

--- a/Assets/Scripts/Util/Input.meta
+++ b/Assets/Scripts/Util/Input.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 13943b3ae3bb7e949b0b58b50deb7823
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Util/Input/Vector2InputDeadzone.cs
+++ b/Assets/Scripts/Util/Input/Vector2InputDeadzone.cs
@@ -1,0 +1,44 @@
+using UnityEngine;
+using UnityEngine.Events;
+using UnityEngine.InputSystem;
+
+/**
+ * Replaces context.started and context.cancelled with UnityEvents for inputs using a custom deadzone.
+ */
+public class Vector2InputDeadzone : MonoBehaviour
+{
+    [Header("Variables")]
+    [Tooltip("Events will be triggered after the magnitude of the input vector exceeds this value. Behaviour is undefined if the default deadzone exceeds this value.")]
+    [Range(0, 1)]
+    [SerializeField]
+    private float deadzone;    
+    [Space]
+    [Header("Events")]
+    [SerializeField]
+    private UnityEvent<Vector2> OnInputStarted;
+    [SerializeField]
+    private UnityEvent OnInputCanceled;
+
+    private bool isInputStarted;
+    private float sqrDeadzone;
+
+    private void Awake()
+    {
+        sqrDeadzone = deadzone * deadzone; //Precalculate to compare vector sqrMagnitudes and avoid a sqr root calc each input update.
+    }
+
+    public void OnInput(InputAction.CallbackContext context)
+    {
+        Vector2 input_value = context.ReadValue<Vector2>();
+        
+        if(!isInputStarted && input_value.sqrMagnitude > sqrDeadzone)
+        {
+            isInputStarted = true;
+            OnInputStarted.Invoke(input_value);
+        } else if(isInputStarted && input_value.sqrMagnitude < sqrDeadzone)
+        {
+            isInputStarted = false;
+            OnInputCanceled.Invoke();
+        }
+    }
+}

--- a/Assets/Scripts/Util/Input/Vector2InputDeadzone.cs.meta
+++ b/Assets/Scripts/Util/Input/Vector2InputDeadzone.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 34c509e5488763542b074348c53ebcb2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/World/WorldRotationInputListener.cs
+++ b/Assets/Scripts/World/WorldRotationInputListener.cs
@@ -6,7 +6,7 @@ public class WorldRotationInputListener : MonoBehaviour
 {
     [Tooltip("Reference to Is Time Stopped")]
     [SerializeField] private BoolReference isTimeStopped;
-    [SerializeField] private Vector2ToRotationConfig rotationInputMapping;
+    [SerializeField] private Vector2ToRotationConfig rotationInputMapping;    
 
     private WorldRotator worldRotator;
     private Direction rotationDirection;
@@ -53,13 +53,10 @@ public class WorldRotationInputListener : MonoBehaviour
         }
     }
 
-    public void OnRotate(InputAction.CallbackContext context)
+    public void OnRotate(Vector2 input_value)
     {
-        if (context.started)
-        {            
-            Rotation rotation = rotationInputMapping.Vector2ToRotation(context.ReadValue<Vector2>());
-            InvokeWorldRotation(rotation);
-        }
+         Rotation rotation = rotationInputMapping.Vector2ToRotation(input_value);
+         InvokeWorldRotation(rotation);        
     }
 
     private void InvokeWorldRotation(Rotation rotation)


### PR DESCRIPTION
A bug in Unity's input system makes input actions with a custom deadzone
register input events incorrectly.
New component replaces input action deadzone, along with context.started
and canceled.
Update Inputsystem test scene to use new deadzone.
Update WorldRotation prefab.