### PR TITLE
Added max velocity to dynamic objects, Fixes #67

### DIFF
--- a/Assets/Prefabs/Player/TestPlayer.prefab
+++ b/Assets/Prefabs/Player/TestPlayer.prefab
@@ -145,6 +145,7 @@ MonoBehaviour:
   groundLayer:
     serializedVersion: 2
     m_Bits: 64
+  maxVelocity: 25
   onFallOffEvent: {fileID: 11400000, guid: 70d3ac60554e37846b70955bb8752e0b, type: 2}
   onGroundedEvent: {fileID: 11400000, guid: d5840a8e92e79964ca01cb2359aad136, type: 2}
 --- !u!114 &4265735082826765357

--- a/Assets/Prefabs/World/PushableBlock.prefab
+++ b/Assets/Prefabs/World/PushableBlock.prefab
@@ -149,11 +149,14 @@ MonoBehaviour:
     constantValue: {x: 0, y: 0, z: 0, w: 0}
     variable: {fileID: 11400000, guid: 238e78415a41f744bba393c7ec97fb87, type: 2}
   stageBoundsTag: StageBounds
+  deathGroundTag: DeathGround
   isEssential: 1
   groundLayer:
     serializedVersion: 2
     m_Bits: 64
+  maxVelocity: 25
   onFallOffEvent: {fileID: 11400000, guid: 70d3ac60554e37846b70955bb8752e0b, type: 2}
+  onGroundedEvent: {fileID: 0}
 --- !u!114 &8762914267215524177
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Physics/PhysicsObjects/DynamicObject.cs
+++ b/Assets/Scripts/Physics/PhysicsObjects/DynamicObject.cs
@@ -20,6 +20,8 @@ public class DynamicObject : MonoBehaviour
     [SerializeField] private bool isEssential;
     [Tooltip("What layer do we consider ground for this object.")]
     [SerializeField] private LayerMask groundLayer;
+    [Tooltip("Maximum velocity of this object.")]
+    [SerializeField] private float maxVelocity;
     [Header("Events")]
     [Tooltip("Event to raise if the object falls out of range.")]
     [SerializeField] private GameEvent onFallOffEvent;
@@ -60,7 +62,9 @@ public class DynamicObject : MonoBehaviour
     // Update is called once per frame
     void FixedUpdate()
     {
-        SetData();        
+        SetData();
+        if (body.velocity.magnitude > maxVelocity)
+            body.velocity = body.velocity.normalized * maxVelocity;
     }
 
     public bool IsGrounded()


### PR DESCRIPTION
Calculated to only let the player move half a block at each increment maximum. FixedUpdate goes 50 times/sec, half a block means velocity is limited to 25 units / sec